### PR TITLE
Add reference to Messine paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Departamento de Física, Facultad de Ciencias, Universidad Nacional Autónoma de
 
 ## References
 
+- [Extentions of Affine Arithmetic: Application to Unconstrained Global Optimization](http://www.jucs.org/jucs_8_11/extentions_of_affine_arithmetic), Frédéric Messine
+
 - [Implementation and improvements of affine arithmetic](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwi2icCjwv7SAhVDfiwKHbX9CfoQFggcMAA&url=http%3A%2F%2Fwww.ti3.tuhh.de%2Fpaper%2Frump%2FRuKas14.pdf&usg=AFQjCNFTxm7hWrj95AQ_MvJMihElyT6kLg&sig2=tkeMyVLfhMKB82awYAePkA&bvm=bv.151426398,d.bGg) (2015),
 Siegfried M. Rump and Masahide Kashiwagi
 


### PR DESCRIPTION
This paper proposes the affine form AF1 with *fixed* length that we use (in a modified way) in the new version of the package.